### PR TITLE
feat: ms users attach user identity avatar

### DIFF
--- a/microservices/users/__tests__/services/identity-provider/firebase-test.ts
+++ b/microservices/users/__tests__/services/identity-provider/firebase-test.ts
@@ -111,6 +111,23 @@ describe('services/sign-up', () => {
     );
   });
 
+  it('should register new user without photo', async () => {
+    const { email } = mockUser;
+
+    FirebaseSdkStub.resolves(firebaseMock({ user: { email, emailVerified: true } }));
+    TypeormMock.queryBuilder.getOne.resolves(undefined);
+
+    // mock transaction
+    TypeormMock.entityManager.findOne.resolves(mockProfile());
+    TypeormMock.entityManager.save.resolves(mockUser);
+
+    await service.signIn({ isShouldAttachUserPhoto: false });
+
+    const [, profile] = TypeormMock.entityManager.save.thirdCall.args;
+
+    expect(profile?.photo).to.be.null;
+  });
+
   it('should register new user', async () => {
     const email = 'demo@email.com';
 

--- a/microservices/users/__tests__/services/identity-provider/firebase-test.ts
+++ b/microservices/users/__tests__/services/identity-provider/firebase-test.ts
@@ -111,10 +111,10 @@ describe('services/sign-up', () => {
     );
   });
 
-  it('should register new user without photo', async () => {
-    const { email } = mockUser;
-
-    FirebaseSdkStub.resolves(firebaseMock({ user: { email, emailVerified: true } }));
+  it('should register new user without the photo', async () => {
+    FirebaseSdkStub.resolves(
+      firebaseMock({ user: { email: mockUser.email, emailVerified: true } }),
+    );
     TypeormMock.queryBuilder.getOne.resolves(undefined);
 
     TypeormMock.entityManager.findOne.resolves(mockProfile());
@@ -125,6 +125,22 @@ describe('services/sign-up', () => {
     const [, profile] = TypeormMock.entityManager.save.thirdCall.args;
 
     expect(profile?.photo).to.be.null;
+  });
+
+  it('should register new user with the photo', async () => {
+    FirebaseSdkStub.resolves(
+      firebaseMock({ user: { email: mockUser.email, emailVerified: true } }),
+    );
+    TypeormMock.queryBuilder.getOne.resolves(undefined);
+
+    TypeormMock.entityManager.findOne.resolves(mockProfile());
+    TypeormMock.entityManager.save.resolves(mockUser);
+
+    await service.signIn();
+
+    const [, profile] = TypeormMock.entityManager.save.thirdCall.args;
+
+    expect(profile?.photo).to.be.equal(providerGoogle.photoURL);
   });
 
   it('should register new user', async () => {

--- a/microservices/users/__tests__/services/identity-provider/firebase-test.ts
+++ b/microservices/users/__tests__/services/identity-provider/firebase-test.ts
@@ -117,7 +117,6 @@ describe('services/sign-up', () => {
     FirebaseSdkStub.resolves(firebaseMock({ user: { email, emailVerified: true } }));
     TypeormMock.queryBuilder.getOne.resolves(undefined);
 
-    // mock transaction
     TypeormMock.entityManager.findOne.resolves(mockProfile());
     TypeormMock.entityManager.save.resolves(mockUser);
 

--- a/microservices/users/src/services/identity-provider/abstract.ts
+++ b/microservices/users/src/services/identity-provider/abstract.ts
@@ -84,13 +84,6 @@ abstract class Abstract {
   public abstract attachProvider(userId: string, params?: Record<string, any>): Promise<User>;
 
   /**
-   * Set is should attach user photo
-   */
-  protected setIsShouldAttachUserPhoto(isShouldAttachUserPhoto: boolean) {
-    this.isShouldAttachUserPhoto = isShouldAttachUserPhoto;
-  }
-
-  /**
    * Validate entities
    * @private
    */

--- a/microservices/users/src/services/identity-provider/abstract.ts
+++ b/microservices/users/src/services/identity-provider/abstract.ts
@@ -16,15 +16,21 @@ export interface ISingInReturn {
  * isDenyRegister - prevent sign in if user exist
  * isDenyAuthViaRegister - prevent sign in if user exist (split sign up/sign in)
  */
-export type TSingInParams = { isDenyRegister?: boolean; isDenyAuthViaRegister?: boolean } & Record<
-  string,
-  any
->;
+export type TSingInParams = {
+  isDenyRegister?: boolean;
+  isDenyAuthViaRegister?: boolean;
+  isShouldAttachUserPhoto?: boolean;
+} & Record<string, any>;
 
 /**
  * Abstract class for identity providers
  */
 abstract class Abstract {
+  /**
+   * Is should attach user photo
+   */
+  protected isShouldAttachUserPhoto = true;
+
   /**
    * @protected
    */
@@ -76,6 +82,13 @@ abstract class Abstract {
    * Attach new identity provider to existing user
    */
   public abstract attachProvider(userId: string, params?: Record<string, any>): Promise<User>;
+
+  /**
+   * Set is should attach user photo
+   */
+  protected setIsShouldAttachUserPhoto(isShouldAttachUserPhoto: boolean) {
+    this.isShouldAttachUserPhoto = isShouldAttachUserPhoto;
+  }
 
   /**
    * Validate entities

--- a/microservices/users/src/services/identity-provider/firebase.ts
+++ b/microservices/users/src/services/identity-provider/firebase.ts
@@ -109,7 +109,7 @@ class Firebase extends Abstract {
    * NOTE: Uses while user on split sign up want to upload own photo,
    * in this case we don't need to set photo from user provider result
    */
-  protected getUserPhoto(firebaseUser: UserRecord) {
+  protected getUserPhoto(firebaseUser: UserRecord): string | null {
     if (!this.isShouldAttachUserPhoto) {
       return null;
     }

--- a/microservices/users/src/services/identity-provider/firebase.ts
+++ b/microservices/users/src/services/identity-provider/firebase.ts
@@ -25,7 +25,7 @@ class Firebase extends Abstract {
     const [firebaseUser, providerType] = await this.getFirebaseUser();
     const user = await this.userRepository.findUserByIdentifier(this.provider, firebaseUser.uid);
 
-    this.setIsShouldAttachUserPhoto(isShouldAttachUserPhoto);
+    this.isShouldAttachUserPhoto = isShouldAttachUserPhoto;
 
     if (!user) {
       if (isDenyRegister) {


### PR DESCRIPTION
This flow allows to remove redundant api call on remove avatar (in this case it will be - profile.update where photo will be null) flow from user profile if user wanna to upload own photo