### PR TITLE
feat(blog): add extra information field for article

### DIFF
--- a/microservices/blog/__mocks__/article.ts
+++ b/microservices/blog/__mocks__/article.ts
@@ -6,7 +6,7 @@ const articleMock = {
   content:
     '<div><p>Marianne jointure attended she hastened surprise but she.</p><p> Ever lady son yet you very paid form away.</p></div>',
   extra: {
-    authorName: 'John Doe',
+    links: ['https://google.com', 'https://wikipedia.com'],
   },
 };
 

--- a/microservices/blog/__mocks__/article.ts
+++ b/microservices/blog/__mocks__/article.ts
@@ -5,6 +5,9 @@ const articleMock = {
     'In by an appetite no humoured returned informed. Possession so comparison inquietude he he conviction no decisively.',
   content:
     '<div><p>Marianne jointure attended she hastened surprise but she.</p><p> Ever lady son yet you very paid form away.</p></div>',
+  extra: {
+    authorName: 'John Doe',
+  },
 };
 
 /* eslint-disable import/prefer-default-export */

--- a/microservices/blog/migrations/1693301991584-init.ts
+++ b/microservices/blog/migrations/1693301991584-init.ts
@@ -8,7 +8,7 @@ export default class init1693301991584 implements MigrationInterface {
      * Tables
      */
     await queryRunner.query(
-      `CREATE TABLE "article" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "userId" character varying(36), "title" character varying(255) NOT NULL, "alias" character varying(255) NOT NULL, "description" character varying(255) NOT NULL, "content" text NOT NULL DEFAULT '', "publishDate" TIMESTAMP, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "article(uq):alias" UNIQUE ("alias"), CONSTRAINT "article(pk):id" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "article" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "userId" character varying(36), "title" character varying(255) NOT NULL, "alias" character varying(255) NOT NULL, "description" character varying(255) NOT NULL, "content" text NOT NULL DEFAULT '', "publishDate" TIMESTAMP,  "extra" json NOT NULL DEFAULT '{}', "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "article(uq):alias" UNIQUE ("alias"), CONSTRAINT "article(pk):id" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `CREATE TABLE "category" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying(50) NOT NULL, "alias" character varying(255) NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "category(uq):alias" UNIQUE ("alias"), CONSTRAINT "category(pk):id" PRIMARY KEY ("id"))`,

--- a/microservices/blog/src/entities/article.ts
+++ b/microservices/blog/src/entities/article.ts
@@ -55,9 +55,7 @@ class Article {
   publishDate: string | null;
 
   @JSONSchema({
-    description:
-      'Set of key-value pairs that can be attach to an article.' +
-      'This can be useful for storing extra information about the article in a structured format.',
+    description: 'Used for storing dynamic data. For example extra links or extra authors.',
   })
   @Column({ type: 'json', default: {} })
   @IsUndefinable()

--- a/microservices/blog/src/entities/article.ts
+++ b/microservices/blog/src/entities/article.ts
@@ -54,6 +54,16 @@ class Article {
   @IsNullable()
   publishDate: string | null;
 
+  @JSONSchema({
+    description:
+      'Set of key-value pairs that can be attach to an article.' +
+      'This can be useful for storing extra information about the article in a structured format.',
+  })
+  @Column({ type: 'json', default: {} })
+  @IsUndefinable()
+  @IsObject()
+  extra: Record<string, any>;
+
   @IsTypeormDate()
   @CreateDateColumn()
   createdAt: Date;

--- a/microservices/blog/src/entities/article.ts
+++ b/microservices/blog/src/entities/article.ts
@@ -55,7 +55,15 @@ class Article {
   publishDate: string | null;
 
   @JSONSchema({
-    description: 'Used for storing dynamic data. For example extra links or extra authors.',
+    description: 'Used for storing dynamic data',
+    example: {
+      links: ['https://google.com', 'https://wikipedia.com'],
+      extraAuthor: {
+        name: 'John Doe',
+        link: 'https://facebook.com',
+        email: 'johndoe@gmail.com',
+      },
+    },
   })
   @Column({ type: 'json', default: {} })
   @IsUndefinable()


### PR DESCRIPTION
Extra data field uses to store some information about article, that can differ in different applications, for example in one need to store some extra links, in another extra authors and so on