### PR TITLE
feat(notification): add exclude users without email

### DIFF
--- a/microservices/notification/__tests__/services/task-handlers/email-all-test.ts
+++ b/microservices/notification/__tests__/services/task-handlers/email-all-test.ts
@@ -1,0 +1,34 @@
+import { Api } from '@lomray/microservice-helpers';
+import { TypeormMock } from '@lomray/microservice-helpers/mocks';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { taskMock } from '@__mocks__/task';
+import TaskType from '@constants/task-type';
+import EmailAll from '@services/task-handlers/email-all';
+
+describe('services/task-handlers/email-all', () => {
+  const sandbox = sinon.createSandbox();
+  let apiGet: sinon.SinonStub;
+  let emailAll: EmailAll;
+
+  beforeEach(() => {
+    TypeormMock.sandbox.reset();
+    emailAll = new EmailAll(TypeormMock.entityManager);
+    apiGet = sinon.stub(Api, 'get');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    apiGet.restore();
+  });
+
+  describe('take', () => {
+    it('should correctly return false: task type is not email all', () => {
+      expect(emailAll.take([taskMock])).to.false;
+    });
+
+    it('should correctly return true: task type is email all', () => {
+      expect(emailAll.take([{ ...taskMock, type: TaskType.EMAIL_ALL }])).to.true;
+    });
+  });
+});

--- a/microservices/notification/__tests__/services/task-handlers/email-all-test.ts
+++ b/microservices/notification/__tests__/services/task-handlers/email-all-test.ts
@@ -1,5 +1,6 @@
 import { Api } from '@lomray/microservice-helpers';
 import { TypeormMock } from '@lomray/microservice-helpers/mocks';
+import { waitResult } from '@lomray/microservice-helpers/test-helpers';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { taskMock } from '@__mocks__/task';
@@ -29,6 +30,39 @@ describe('services/task-handlers/email-all', () => {
 
     it('should correctly return true: task type is email all', () => {
       expect(emailAll.take([{ ...taskMock, type: TaskType.EMAIL_ALL }])).to.true;
+    });
+  });
+
+  describe('sendEmailToAllUsers', () => {
+    it('should correctly send email to all users', async () => {
+      const getTotalUsersCountStub = sandbox.stub();
+      const executeEmailAllTaskStub = sandbox.stub();
+
+      await emailAll['sendEmailToAllUsers'].call(
+        {
+          getTotalUsersCount: getTotalUsersCountStub,
+          executeEmailAllTask: executeEmailAllTaskStub,
+          currentPage: 1,
+        },
+        taskMock,
+      );
+
+      expect(getTotalUsersCountStub).to.calledOnce;
+      expect(getTotalUsersCountStub.args[0][0]).to.equal(true);
+      expect(executeEmailAllTaskStub).to.calledOnce;
+    });
+
+    it('should throw error: failed to send email to all users', async () => {
+      const getTotalUsersCountStub = sandbox.stub().throws(new Error('Failed to get users count'));
+
+      expect(
+        await waitResult(
+          emailAll['sendEmailToAllUsers'].call(
+            { getTotalUsersCount: getTotalUsersCountStub },
+            taskMock,
+          ),
+        ),
+      ).to.throw('Failed to get users count');
     });
   });
 });

--- a/microservices/notification/__tests__/services/task-handlers/email-group-test.ts
+++ b/microservices/notification/__tests__/services/task-handlers/email-group-test.ts
@@ -7,6 +7,7 @@ import { taskMock } from '@__mocks__/task';
 import TaskType from '@constants/task-type';
 import Message from '@entities/message';
 import Recipient from '@entities/recipient';
+import type AbstractEmailProvider from '@services/email-provider/abstract';
 import EmailGroup from '@services/task-handlers/email-group';
 
 describe('services/task-handlers/email-group', () => {
@@ -89,6 +90,26 @@ describe('services/task-handlers/email-group', () => {
 
       expect(sendEmailToRecipientsStub).to.calledOnce;
       expect(checkIsMessageTemplateValidStub).to.calledOnce;
+    });
+  });
+
+  describe('executeTask', () => {
+    it('should throw error: users API error', async () => {
+      apiGet.returns({
+        users: {
+          user: {
+            list() {
+              return { error: { message: 'Users API error.' } };
+            },
+          },
+        },
+      });
+
+      expect(
+        await waitResult(
+          emailGroup['executeTask']({} as AbstractEmailProvider, [{}] as Recipient[]),
+        ),
+      ).to.throw('Users API error.');
     });
   });
 });

--- a/microservices/notification/__tests__/services/task-handlers/email-group-test.ts
+++ b/microservices/notification/__tests__/services/task-handlers/email-group-test.ts
@@ -1,0 +1,94 @@
+import { Api } from '@lomray/microservice-helpers';
+import { TypeormMock } from '@lomray/microservice-helpers/mocks';
+import { waitResult } from '@lomray/microservice-helpers/test-helpers';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { taskMock } from '@__mocks__/task';
+import TaskType from '@constants/task-type';
+import Message from '@entities/message';
+import Recipient from '@entities/recipient';
+import EmailGroup from '@services/task-handlers/email-group';
+
+describe('services/task-handlers/email-group', () => {
+  const sandbox = sinon.createSandbox();
+  let apiGet: sinon.SinonStub;
+  let emailGroup: EmailGroup;
+  const messageRepository = TypeormMock.entityManager.getRepository(Message);
+  const recipientRepository = TypeormMock.entityManager.getRepository(Recipient);
+
+  beforeEach(() => {
+    TypeormMock.sandbox.reset();
+    emailGroup = new EmailGroup(TypeormMock.entityManager);
+    apiGet = sinon.stub(Api, 'get');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    apiGet.restore();
+  });
+
+  describe('take', () => {
+    it('should correctly return false: task type is not email group', () => {
+      expect(emailGroup.take([taskMock])).to.false;
+    });
+
+    it('should correctly return true: task type is email group', () => {
+      expect(emailGroup.take([{ ...taskMock, type: TaskType.EMAIL_GROUP }])).to.true;
+    });
+  });
+
+  describe('sendEmailToRecipients', () => {
+    it('should correctly send email to recipients', async () => {
+      const executeTaskStub = sandbox.stub();
+
+      await emailGroup['sendEmailToRecipients'].call(
+        {
+          messageTemplate: { taskId: 'id' },
+          messageRepository,
+          recipientRepository,
+          executeTask: executeTaskStub,
+        },
+        taskMock,
+      );
+
+      expect(executeTaskStub).to.calledOnce;
+    });
+  });
+
+  describe('processTasks', () => {
+    it('should correctly exit process: task template was not found', async () => {
+      const sendEmailToRecipientsStub = sandbox.stub();
+
+      expect(
+        await waitResult(
+          emailGroup['processTasks'].call(
+            {
+              messageTemplate: { taskId: 'id' },
+              manager: TypeormMock.entityManager,
+              endEmailToRecipients: sendEmailToRecipientsStub,
+            },
+            taskMock,
+          ),
+        ),
+      ).to.throw('Task message template was not found.');
+    });
+
+    it('should correctly process tasks', async () => {
+      const sendEmailToRecipientsStub = sandbox.stub();
+      const checkIsMessageTemplateValidStub = sandbox.stub().resolves(true);
+
+      await emailGroup['processTasks'].call(
+        {
+          messageTemplate: { taskId: 'id' },
+          manager: TypeormMock.entityManager,
+          sendEmailToRecipients: sendEmailToRecipientsStub,
+          checkIsMessageTemplateValid: checkIsMessageTemplateValidStub,
+        },
+        { ...taskMock, messages: [{ params: { isTemplate: true } }] },
+      );
+
+      expect(sendEmailToRecipientsStub).to.calledOnce;
+      expect(checkIsMessageTemplateValidStub).to.calledOnce;
+    });
+  });
+});

--- a/microservices/notification/__tests__/services/task-handlers/notice-all-test.ts
+++ b/microservices/notification/__tests__/services/task-handlers/notice-all-test.ts
@@ -8,7 +8,7 @@ import { taskMock } from '@__mocks__/task';
 import TaskType from '@constants/task-type';
 import NoticeAll from '@services/task-handlers/notice-all';
 
-describe('services/task-handlers/abstract', () => {
+describe('services/task-handlers/notice-all', () => {
   const sandbox = sinon.createSandbox();
   let apiGet: sinon.SinonStub;
   let noticeAll: NoticeAll;

--- a/microservices/notification/__tests__/services/task-handlers/notice-all-test.ts
+++ b/microservices/notification/__tests__/services/task-handlers/notice-all-test.ts
@@ -64,4 +64,37 @@ describe('services/task-handlers/notice-all', () => {
       ).to.throw('Task notice template was not found.');
     });
   });
+
+  describe('sendNoticeToAllUsers', () => {
+    it('should correctly send notice to all users', async () => {
+      const getTotalUsersCountStub = sandbox.stub();
+      const executeNoticeAllTaskStub = sandbox.stub();
+
+      await noticeAll['sendNoticeToAllUsers'].call(
+        {
+          getTotalUsersCount: getTotalUsersCountStub,
+          executeNoticeAllTask: executeNoticeAllTaskStub,
+          currentPage: 1,
+        },
+        taskMock,
+      );
+
+      expect(getTotalUsersCountStub).to.calledOnce;
+      expect(getTotalUsersCountStub.args[0][0]).to.equal(undefined);
+      expect(executeNoticeAllTaskStub).to.calledOnce;
+    });
+
+    it('should throw error: failed to send notice to all users', async () => {
+      const getTotalUsersCountStub = sandbox.stub().throws(new Error('Failed to get users count'));
+
+      expect(
+        await waitResult(
+          noticeAll['sendNoticeToAllUsers'].call(
+            { getTotalUsersCount: getTotalUsersCountStub },
+            taskMock,
+          ),
+        ),
+      ).to.throw('Failed to get users count');
+    });
+  });
 });

--- a/microservices/notification/__tests__/services/task/index-test.ts
+++ b/microservices/notification/__tests__/services/task/index-test.ts
@@ -1,0 +1,63 @@
+import { TypeormMock } from '@lomray/microservice-helpers/mocks';
+import { waitResult } from '@lomray/microservice-helpers/test-helpers';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { noticeMock } from '@__mocks__/notice';
+import { taskMock } from '@__mocks__/task';
+import TaskType from '@constants/task-type';
+import Notice from '@entities/notice';
+import TaskEntity from '@entities/task';
+import Task from '@services/task';
+
+describe('services/email-provider/factory', () => {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(() => {
+    TypeormMock.sandbox.reset();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('handleAfterInsert', () => {
+    it('should create and attach recipients', async () => {
+      const handleAttachStub = sandbox.stub();
+
+      await Task.handleAfterInsert.call(
+        { handleAttach: handleAttachStub },
+        {} as TaskEntity,
+        TypeormMock.entityManager,
+      );
+
+      expect(handleAttachStub).to.calledOnce;
+    });
+  });
+
+  describe('handleAttach', () => {
+    it('should throw an error if task type is not expected', async () => {
+      expect(
+        await waitResult(
+          // @ts-ignore
+          Task['handleAttach']({ ...taskMock, type: 'unknown' }, TypeormMock.entityManager),
+        ),
+      ).to.throw('Unexpected task type.');
+    });
+
+    it('should correctly handle notice all type', async () => {
+      const createAndAttachNoticeTemplateStub = sandbox.stub();
+
+      await Task['handleAttach'].call(
+        { createAndAttachNoticeTemplate: createAndAttachNoticeTemplateStub },
+        {
+          ...taskMock,
+          type: TaskType.NOTICE_ALL,
+          notices: [{ ...noticeMock, params: { isTemplate: true } } as Notice],
+        },
+        TypeormMock.entityManager,
+      );
+
+      expect(createAndAttachNoticeTemplateStub).to.calledOnce;
+    });
+  });
+});

--- a/microservices/notification/src/services/task-handlers/abstract.ts
+++ b/microservices/notification/src/services/task-handlers/abstract.ts
@@ -1,4 +1,5 @@
 import { Api, Log } from '@lomray/microservice-helpers';
+import { JQOperator } from '@lomray/microservices-types/lib/src/query';
 import _ from 'lodash';
 import { EntityManager, Repository } from 'typeorm';
 import TaskStatus from '@constants/task-status';
@@ -118,9 +119,22 @@ abstract class Abstract {
 
   /**
    * Get total users count
+   * @description Users without email - facebook users that does not give access for their email
    */
-  protected async getTotalUsersCount(): Promise<number> {
-    const { result: usersCountResult, error: usersCountError } = await Api.get().users.user.count();
+  protected async getTotalUsersCount(excludeUsersWithoutEmail = false): Promise<number> {
+    const { result: usersCountResult, error: usersCountError } = await Api.get().users.user.count(
+      excludeUsersWithoutEmail
+        ? {
+            query: {
+              where: {
+                email: {
+                  [JQOperator.isNotNULL]: null,
+                },
+              },
+            },
+          }
+        : undefined,
+    );
 
     if (usersCountError) {
       // Internal error. Case where error target doesn't exist

--- a/microservices/notification/src/services/task-handlers/abstract.ts
+++ b/microservices/notification/src/services/task-handlers/abstract.ts
@@ -1,5 +1,5 @@
 import { Api, Log } from '@lomray/microservice-helpers';
-import { JQOperator } from '@lomray/microservices-types/lib/src/query';
+import { JQOperator } from '@lomray/microservices-types';
 import _ from 'lodash';
 import { EntityManager, Repository } from 'typeorm';
 import TaskStatus from '@constants/task-status';

--- a/microservices/notification/src/services/task-handlers/email-all.ts
+++ b/microservices/notification/src/services/task-handlers/email-all.ts
@@ -1,5 +1,6 @@
 import { Api, Log } from '@lomray/microservice-helpers';
 import type IUser from '@lomray/microservices-client-api/interfaces/users/entities/user';
+import { JQOperator } from '@lomray/microservices-types/lib/src/query';
 import _ from 'lodash';
 import { In, Repository } from 'typeorm';
 import TaskMode from '@constants/task-mode';
@@ -65,7 +66,7 @@ class EmailAll extends Abstract {
    * @description Get all users count and execute task
    */
   private async sendEmailToAllUsers(task: TaskEntity): Promise<void> {
-    const usersCount = await this.getTotalUsersCount();
+    const usersCount = await this.getTotalUsersCount(true);
 
     try {
       await this.executeEmailAllTask(task, usersCount);
@@ -98,6 +99,11 @@ class EmailAll extends Abstract {
           page: this.currentPage,
           pageSize: this.chunkSize,
           orderBy: { createdAt: 'ASC' },
+          where: {
+            email: {
+              [JQOperator.isNotNULL]: null,
+            },
+          },
         },
       });
 

--- a/microservices/notification/src/services/task-handlers/email-all.ts
+++ b/microservices/notification/src/services/task-handlers/email-all.ts
@@ -1,6 +1,6 @@
 import { Api, Log } from '@lomray/microservice-helpers';
 import type IUser from '@lomray/microservices-client-api/interfaces/users/entities/user';
-import { JQOperator } from '@lomray/microservices-types/lib/src/query';
+import { JQOperator } from '@lomray/microservices-types';
 import _ from 'lodash';
 import { In, Repository } from 'typeorm';
 import TaskMode from '@constants/task-mode';

--- a/microservices/notification/src/services/task-handlers/email-group.ts
+++ b/microservices/notification/src/services/task-handlers/email-group.ts
@@ -38,7 +38,7 @@ class EmailGroup extends Abstract {
     this.messageRepository = this.manager.getRepository(MessageEntity);
     this.recipientRepository = this.manager.getRepository(RecipientEntity);
 
-    const messageTemplate = task.messages.find(({ params }) => params.isTemplate);
+    const messageTemplate = task.messages?.find(({ params }) => params.isTemplate);
 
     if (!messageTemplate) {
       // Internal error

--- a/microservices/notification/src/services/task-handlers/email-group.ts
+++ b/microservices/notification/src/services/task-handlers/email-group.ts
@@ -102,19 +102,21 @@ class EmailGroup extends Abstract {
       },
     });
 
-    if (usersListError) {
-      Log.error(usersListError.message);
+    if (usersListError || !usersListResult) {
+      Log.error(usersListError?.message);
 
-      throw new Error(usersListError.message);
+      throw new Error(usersListError?.message);
     }
 
-    if (usersListResult?.list.some(({ email }) => !email)) {
+    const { list: users } = usersListResult;
+
+    if (users.some(({ email }) => !email)) {
       // Throw internal error
       throw new Error('Some users have no email.');
     }
 
     await Promise.all(
-      usersListResult!.list.map(({ email, id }) =>
+      users.map(({ email, id }) =>
         sendService.send({
           html: this.messageTemplate.html as string,
           taskId: this.messageTemplate.taskId as string,


### PR DESCRIPTION
Exlude users from email notifications 
Case: User sign upped from facebook and did not share and set up different email