### PR TITLE
feat(users): update admin change user password validators

### DIFF
--- a/http-requests/users/requests.http
+++ b/http-requests/users/requests.http
@@ -21,3 +21,21 @@ Authorization: Bearer admintokenooooooooooooooooooooon
     }
   }
 }
+
+### Change user password as an application admin
+POST http://127.0.0.1:3000
+Accept: application/json
+Content-Type: application/json
+## Admin token
+Authorization: Bearer admintokenooooooooooooooooooooon
+
+{
+  "id": "1",
+  "method": "users.user.change-password",
+  "params": {
+    "userId": "68827b31-33e9-45b5-bf9f-8823b993d0ef",
+    "newPassword": "123456789!A",
+    "allowedByAdmin": true
+  }
+}
+

--- a/microservices/users/src/methods/user/change-password.ts
+++ b/microservices/users/src/methods/user/change-password.ts
@@ -1,5 +1,6 @@
 import { Endpoint, IsType, IsUndefinable } from '@lomray/microservice-helpers';
 import { IsBoolean, IsEnum, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+import { JSONSchema } from 'class-validator-jsonschema';
 import { getCustomRepository, getRepository } from 'typeorm';
 import ConfirmCode from '@entities/confirm-code';
 import User from '@entities/user';
@@ -23,18 +24,28 @@ class ChangePasswordInput {
   @IsNotEmpty()
   newPassword: string;
 
+  @JSONSchema({
+    description: 'Skip if change password has allowed by admin',
+  })
   @IsString()
   @IsNotEmpty()
-  @ValidateIf(({ confirmCode, oldPassword }) => !confirmCode || oldPassword)
+  @ValidateIf(
+    ({ confirmCode, oldPassword, allowByAdmin }) => !allowByAdmin && (!confirmCode || oldPassword),
+  )
   oldPassword?: string;
 
   @IsEnum(ConfirmBy)
   @ValidateIf(({ confirmCode }) => confirmCode)
   confirmBy?: ConfirmBy;
 
+  @JSONSchema({
+    description: 'Skip if change password has allowed by admin',
+  })
   @IsType(['string', 'number'])
   @IsNotEmpty()
-  @ValidateIf(({ confirmCode, oldPassword }) => !oldPassword || confirmCode)
+  @ValidateIf(
+    ({ confirmCode, oldPassword, allowByAdmin }) => !allowByAdmin && (!oldPassword || confirmCode),
+  )
   confirmCode?: string | number;
 
   @IsBoolean()


### PR DESCRIPTION
Update "validateIf" validator for change password input:
If "allowByAdmin" is truthly - user (admin) is eligible to change user password without passing confirm code and old password